### PR TITLE
example of a complicated edge case w/r to expression visiting

### DIFF
--- a/tests/NoUselessCmdNoneTest.elm
+++ b/tests/NoUselessCmdNoneTest.elm
@@ -212,4 +212,21 @@ update msg model =
                             }
                             |> Review.Test.atExactly { start = { row = 12, column = 22 }, end = { row = 12, column = 30 } }
                         ]
+        , test "should not report Cmd.none that's not in a return value" <|
+            \() ->
+                """module A exposing (..)
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    if (case msg of
+          ClickedIncrement ->
+            ( model + 1, Cmd.none )
+        ) |> Tuple.first
+    then
+        (model, cmd)
+    else
+        (model, cmd2)
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors []
         ]


### PR DESCRIPTION
From twitch chat:

> avh4: jfmengels here's the failing test of the weird edge case I was talking about earlier ... admittedly I think it's unlikely that real users would hit this case, but it is possible
> avh4: beecause the expression visitor will visit all the expressions, but you really only want to visit the ones that are possible return values for the body of the top-level definition
> avh4: anyway, not get bogged down in that now, but I think it's an interesting theoretical limitation of the available vistors